### PR TITLE
Dedicated parsing logic

### DIFF
--- a/src/main/java/com/rolerandomizer/BaRole.java
+++ b/src/main/java/com/rolerandomizer/BaRole.java
@@ -1,0 +1,23 @@
+package com.rolerandomizer;
+
+import java.awt.Color;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.client.util.Text;
+
+@RequiredArgsConstructor
+public enum BaRole
+{
+	ATTACKER(Color.RED.darker()),
+	DEFENDER(Color.BLUE.darker()),
+	COLLECTOR(Color.YELLOW),
+	HEALER(Color.GREEN.darker().darker());
+
+	@Getter
+	private final Color color;
+
+	public String displayName()
+	{
+		return Text.titleCase(this);
+	}
+}

--- a/src/main/java/com/rolerandomizer/CannotDetermineRolesException.java
+++ b/src/main/java/com/rolerandomizer/CannotDetermineRolesException.java
@@ -1,0 +1,9 @@
+package com.rolerandomizer;
+
+public class CannotDetermineRolesException extends Exception
+{
+	public CannotDetermineRolesException()
+	{
+		super("Cannot determine role prefs for all 5 players");
+	}
+}

--- a/src/main/java/com/rolerandomizer/CannotParseArgException.java
+++ b/src/main/java/com/rolerandomizer/CannotParseArgException.java
@@ -1,0 +1,9 @@
+package com.rolerandomizer;
+
+public class CannotParseArgException extends Exception
+{
+	public CannotParseArgException(String arg)
+	{
+		super(arg + " is not a valid player name or role");
+	}
+}

--- a/src/main/java/com/rolerandomizer/InputCandidate.java
+++ b/src/main/java/com/rolerandomizer/InputCandidate.java
@@ -1,0 +1,18 @@
+package com.rolerandomizer;
+
+import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Strings sent as arguments could be interpreted as player names or roles
+ */
+@RequiredArgsConstructor
+public enum InputCandidate
+{
+	NAME(Pattern.compile("[A-Za-z0-9_-]{1,12}")),
+	ROLE(Pattern.compile("[m2ahcd]{1,5}|fill|" + MetaRoleInfo.SLASH_SEPARATED_MATCHER));
+
+	@Getter
+	private final Pattern pattern;
+}

--- a/src/main/java/com/rolerandomizer/MetaRoleInfo.java
+++ b/src/main/java/com/rolerandomizer/MetaRoleInfo.java
@@ -15,11 +15,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MetaRoleInfo
 {
-	MAIN_ATTACKER("Main attacker", BaRole.ATTACKER, ImmutableSet.of("m", "(?<!2)a")),
-	SECOND_ATTACKER("2nd attacker", BaRole.ATTACKER, ImmutableSet.of("2", "2a", "a")),
-	HEALER("Healer", BaRole.HEALER, ImmutableSet.of("h")),
-	COLLECTOR("Collector", BaRole.COLLECTOR, ImmutableSet.of("c")),
-	DEFENDER("Defender", BaRole.DEFENDER, ImmutableSet.of("d"));
+	MAIN_ATTACKER("Main attacker", "m", BaRole.ATTACKER, ImmutableSet.of("m", "(?<!2)a")),
+	SECOND_ATTACKER("2nd attacker", "2", BaRole.ATTACKER, ImmutableSet.of("2", "2a", "a")),
+	HEALER("Healer", "h", BaRole.HEALER, ImmutableSet.of("h")),
+	COLLECTOR("Collector", "c", BaRole.COLLECTOR, ImmutableSet.of("c")),
+	DEFENDER("Defender", "d", BaRole.DEFENDER, ImmutableSet.of("d"));
 
 	// one or more of any of the possible matches, separated by slashes
 	public static final String SLASH_SEPARATED_MATCHER;
@@ -37,7 +37,9 @@ public enum MetaRoleInfo
 	}
 
 	@Getter
-	private final String displayName;
+	private final String fullName;
+	@Getter
+	private final String shortName;
 	@Getter
 	private final BaRole role;
 	@Getter

--- a/src/main/java/com/rolerandomizer/MetaRoleInfo.java
+++ b/src/main/java/com/rolerandomizer/MetaRoleInfo.java
@@ -1,0 +1,46 @@
+package com.rolerandomizer;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Not to be confused with the regular BA role, this describes a more specific team role in the context of
+ * the BA metagame. Currently, it distinguishes between main and second attacker roles in funs.
+ *
+ * @see com.rolerandomizer.BaRole
+ */
+@RequiredArgsConstructor
+public enum MetaRoleInfo
+{
+	MAIN_ATTACKER("Main attacker", BaRole.ATTACKER, ImmutableSet.of("m", "(?<!2)a")),
+	SECOND_ATTACKER("2nd attacker", BaRole.ATTACKER, ImmutableSet.of("2", "2a", "a")),
+	HEALER("Healer", BaRole.HEALER, ImmutableSet.of("h")),
+	COLLECTOR("Collector", BaRole.COLLECTOR, ImmutableSet.of("c")),
+	DEFENDER("Defender", BaRole.DEFENDER, ImmutableSet.of("d"));
+
+	// one or more of any of the possible matches, separated by slashes
+	public static final String SLASH_SEPARATED_MATCHER;
+
+	static
+	{
+		Set<String> all = new HashSet<>();
+		all.addAll(MAIN_ATTACKER.matches);
+		all.addAll(SECOND_ATTACKER.matches);
+		all.addAll(HEALER.matches);
+		all.addAll(COLLECTOR.matches);
+		all.addAll(DEFENDER.matches);
+		String ors = "[" + String.join("|", all) + "]";
+		SLASH_SEPARATED_MATCHER = ors + "(?:/" + ors + ")*";
+	}
+
+	@Getter
+	private final String displayName;
+	@Getter
+	private final BaRole role;
+	@Getter
+	private final Set<String> matches;
+
+}

--- a/src/main/java/com/rolerandomizer/PlayerPrefs.java
+++ b/src/main/java/com/rolerandomizer/PlayerPrefs.java
@@ -1,0 +1,11 @@
+package com.rolerandomizer;
+
+import java.util.List;
+import lombok.Value;
+
+@Value
+public class PlayerPrefs
+{
+	String name;
+	List<MetaRoleInfo> prefs;
+}

--- a/src/main/java/com/rolerandomizer/RoleParser.java
+++ b/src/main/java/com/rolerandomizer/RoleParser.java
@@ -1,0 +1,211 @@
+package com.rolerandomizer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class RoleParser
+{
+	private static final List<MetaRoleInfo> ALL_ROLES = Arrays.asList(MetaRoleInfo.values().clone());
+
+	private final Set<Set<PlayerPrefs>> validPrefSets = new HashSet<>();
+	private final List<String> args = new ArrayList<>();
+	private final List<Set<InputCandidate>> argCandidates = new ArrayList<>();
+
+	/**
+	 * Assumptions:
+	 * - rando is requested for 5 players
+	 * - player names contain no spaces
+	 * - no specified role means any role (fill)
+	 * - correct role formats include:
+	 * -- any combination of "m2ahcd" chars, concatenated without repeats, e.g., "2cd" good, "cadah" bad
+	 * -- any slash-separated combination of the above, also without repeats, e.g., "2/c/d" good, "ahc/d" bad
+	 * -- the exact string "fill", no more and no less
+	 *
+	 * @param inputs list of string input from the command (split by whitespace)
+	 * @return list of PlayerPrefs, in lexicographical order by player name
+	 */
+	public List<PlayerPrefs> parse(List<String> inputs) throws CannotParseArgException, CannotDetermineRolesException
+	{
+		validPrefSets.clear();
+		argCandidates.clear();
+		args.clear();
+		args.addAll(inputs);
+		determineCandidates();
+		determinePrefs();
+		// out of all valid results, result with shortest char count in player names is likely most sensible
+		Set<PlayerPrefs> bestResult = validPrefSets.stream()
+			.min(Comparator.comparingInt(set -> set.stream().mapToInt(prefs -> prefs.getName().length()).sum()))
+			.orElseThrow(CannotDetermineRolesException::new);
+		return bestResult.stream()
+			.sorted(Comparator.comparing(PlayerPrefs::getName))
+			.collect(Collectors.toList());
+	}
+
+	private void determineCandidates() throws CannotParseArgException
+	{
+		// First determine whether each word could be NAME, ROLE, or both
+		for (String input : args)
+		{
+			Set<InputCandidate> candidates = new HashSet<>();
+			for (InputCandidate ic : InputCandidate.values())
+			{
+				boolean match = ic.getPattern().matcher(input).matches();
+				switch (ic)
+				{
+					case NAME:
+						break;
+					case ROLE:
+						if (!input.equals("fill"))
+						{
+							// Also make sure that the roles have no dupes
+							Set<Character> charSet = input.chars()
+								.mapToObj(e -> (char) e)
+								.filter(e -> e != '/')
+								.collect(Collectors.toSet());
+							String noSlashInput = input.replace("/", "");
+							match &= charSet.size() == noSlashInput.length();
+						}
+						break;
+				}
+				if (match)
+				{
+					candidates.add(ic);
+				}
+			}
+			if (candidates.isEmpty())
+			{
+				throw new CannotParseArgException(input);
+			}
+			argCandidates.add(candidates);
+		}
+	}
+
+	private void determinePrefs()
+	{
+		recurse(argCandidates.size() - 1, new ArrayList<>());
+	}
+
+	// i = current index of args, pending = running list of sub-divisions
+	private void recurse(int i, List<PlayerPrefs> pending)
+	{
+		// base cases: reached beginning of input, or have more than 5 players
+		if (i == -1)
+		{
+			if (isValid(pending))
+			{
+				validPrefSets.add(new HashSet<>(pending));
+			}
+			return;
+		}
+		else if (isInvalid(pending))
+		{
+			return;
+		}
+		String word = args.get(i);
+		Set<InputCandidate> cands = argCandidates.get(i);
+		PlayerPrefs lastPrefs = null;
+		if (!pending.isEmpty())
+		{
+			lastPrefs = pending.get(pending.size() - 1);
+		}
+		if (cands.contains(InputCandidate.ROLE))
+		{
+			// can't have roles b2b, and can't start args with role
+			if ((lastPrefs == null || !lastPrefs.getName().isEmpty()) && i > 0)
+			{
+				List<PlayerPrefs> newPrefs = new ArrayList<>(pending);
+				newPrefs.add(new PlayerPrefs("", prefsFrom(word)));
+				recurse(i - 1, newPrefs);
+			}
+		}
+		if (cands.contains(InputCandidate.NAME))
+		{
+			// start a new name if we have no results yet, or the last thing we found was a name
+			if (lastPrefs == null || !lastPrefs.getName().isEmpty())
+			{
+				List<PlayerPrefs> newPrefs = new ArrayList<>(pending);
+				newPrefs.add(new PlayerPrefs(word, ALL_ROLES));
+				recurse(i - 1, newPrefs);
+			}
+			// if we have a role but not a name, pair that name with that role
+			if (lastPrefs != null && lastPrefs.getName().isEmpty())
+			{
+				List<PlayerPrefs> newPrefs = new ArrayList<>(pending);
+				newPrefs.remove(newPrefs.size() - 1);
+				newPrefs.add(new PlayerPrefs(word, lastPrefs.getPrefs()));
+				recurse(i - 1, newPrefs);
+			}
+		}
+	}
+
+	private List<MetaRoleInfo> prefsFrom(String roleStr)
+	{
+		if (roleStr.equals("fill"))
+		{
+			return ALL_ROLES;
+		}
+		return Arrays.stream(MetaRoleInfo.values())
+			.filter(info -> info.getMatches().stream()
+				.anyMatch(s -> Pattern.compile(s).matcher(roleStr).find()))
+			.collect(Collectors.toList());
+	}
+
+	// prefs are explicitly valid if there are five of them with non-empty, non-repeated names
+	// note: it's possible for a pending list to be neither valid nor invalid (not enough info)
+	private boolean isValid(List<PlayerPrefs> pending)
+	{
+		if (pending.size() != 5)
+		{
+			return false;
+		}
+		Set<String> names = new HashSet<>();
+		for (PlayerPrefs pref : pending)
+		{
+			String name = pref.getName();
+			if (name.isEmpty() || names.contains(name) || name.length() > 12)
+			{
+				return false;
+			}
+			names.add(name);
+		}
+		return true;
+	}
+
+	// parsing is explicitly invalid if any of the following are true:
+	// >5 players, duplicate player names, multiple empty names, a player with a name longer than 12 chars
+	// note: one empty name is ok since it might not have been parsed yet
+	private boolean isInvalid(List<PlayerPrefs> pending)
+	{
+		if (pending.size() > 5)
+		{
+			return true;
+		}
+		Set<String> names = new HashSet<>();
+		boolean hasEmptyNames = false;
+		for (PlayerPrefs pref : pending)
+		{
+			String name = pref.getName();
+			if (name.isEmpty())
+			{
+				if (hasEmptyNames)
+				{
+					return true;
+				}
+				hasEmptyNames = true;
+			}
+			if (names.contains(name) || name.length() > 12)
+			{
+				return true;
+			}
+			names.add(name);
+		}
+		return false;
+	}
+}
+

--- a/src/test/java/com/rolerandomizer/RoleParserTest.java
+++ b/src/test/java/com/rolerandomizer/RoleParserTest.java
@@ -1,0 +1,140 @@
+package com.rolerandomizer;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RoleParserTest
+{
+	private RoleParser parser;
+
+	private static final List<MetaRoleInfo> FILL = Arrays.asList(MetaRoleInfo.values().clone());
+	private static final List<MetaRoleInfo> A_H_C = ImmutableList.of(MetaRoleInfo.MAIN_ATTACKER,
+		MetaRoleInfo.SECOND_ATTACKER, MetaRoleInfo.HEALER, MetaRoleInfo.COLLECTOR);
+	private static final List<MetaRoleInfo> H_C_D = ImmutableList.of(MetaRoleInfo.HEALER, MetaRoleInfo.COLLECTOR,
+		MetaRoleInfo.DEFENDER);
+
+	private static final List<List<String>> GOOD_INPUTS = ImmutableList.of(
+		ImmutableList.of("alice", "bob", "collguy", "defsabo", "egglad"),
+		ImmutableList.of("lugal_ki_en", "fill", "ransty", "a/c/h", "loasted", "fill", "toohey", "fill", "equi"),
+		ImmutableList.of("phil", "fill", "fill", "fill", "me", "m", "somebody", "anybody"),
+		ImmutableList.of("dach", "dch", "mach", "fill", "cahd", "fill", "chad", "fill", "hesi")
+	);
+
+	private static final List<List<PlayerPrefs>> GOOD_OUTPUTS = ImmutableList.of(
+		ImmutableList.of(
+			new PlayerPrefs("alice", FILL),
+			new PlayerPrefs("bob", FILL),
+			new PlayerPrefs("collguy", FILL),
+			new PlayerPrefs("defsabo", FILL),
+			new PlayerPrefs("egglad", FILL)
+		),
+		ImmutableList.of(
+			new PlayerPrefs("equi", FILL),
+			new PlayerPrefs("loasted", FILL),
+			new PlayerPrefs("lugal_ki_en", FILL),
+			new PlayerPrefs("ransty", A_H_C),
+			new PlayerPrefs("toohey", FILL)
+		),
+		ImmutableList.of(
+			new PlayerPrefs("anybody", FILL),
+			new PlayerPrefs("fill", FILL),
+			new PlayerPrefs("me", Collections.singletonList(MetaRoleInfo.MAIN_ATTACKER)),
+			new PlayerPrefs("phil", FILL),
+			new PlayerPrefs("somebody", FILL)
+		),
+		ImmutableList.of(
+			new PlayerPrefs("cahd", FILL),
+			new PlayerPrefs("chad", FILL),
+			new PlayerPrefs("dach", H_C_D),
+			new PlayerPrefs("hesi", FILL),
+			new PlayerPrefs("mach", FILL)
+		)
+	);
+
+	private static final List<List<String>> CANNOT_DETERMINE_INPUTS = ImmutableList.of(
+		ImmutableList.of("not", "enough", "for5"),
+		ImmutableList.of("too", "many", "names", "for", "five", "players"),
+		ImmutableList.of("b2b_roles", "2/c/d", "a/c/h", "phil", "jim", "greg")
+	);
+
+	private static final List<List<String>> BAD_ARGS_INPUTS = ImmutableList.of(
+		ImmutableList.of("v_not_role", "2/h/v", "p2", "p3", "p4", "b5"),
+		ImmutableList.of("no_dupe_roles", "a/a/d", "p2", "p3", "p4", "b5"),
+		ImmutableList.of("bad_slash", "a/ch", "p2", "p3", "p4", "b5"),
+		ImmutableList.of("end_slash", "a/c/", "p2", "p3", "p4", "b5"),
+		ImmutableList.of("fill_plus", "fill/c/d", "p2", "p3", "p4", "b5")
+	);
+
+	@Before
+	public void setUp()
+	{
+		parser = new RoleParser();
+	}
+
+	@Test
+	public void testUnambiguousInputs()
+	{
+		Assert.assertEquals("test case inputs + outputs should be same size",
+			GOOD_OUTPUTS.size(), GOOD_INPUTS.size());
+		for (int i = 0; i < GOOD_INPUTS.size(); i++)
+		{
+			try
+			{
+				List<String> inputs = GOOD_INPUTS.get(i);
+				List<PlayerPrefs> prefs = parser.parse(inputs);
+				Assert.assertEquals(GOOD_OUTPUTS.get(i), prefs);
+			}
+			catch (CannotParseArgException | CannotDetermineRolesException e)
+			{
+				Assert.fail(e.getMessage());
+			}
+		}
+	}
+
+	@Test
+	public void testBadArgs()
+	{
+		for (List<String> inputs : BAD_ARGS_INPUTS)
+		{
+			try
+			{
+				parser.parse(inputs);
+				Assert.fail("should have thrown");
+			}
+			catch (CannotDetermineRolesException e)
+			{
+				Assert.fail(e.getMessage());
+			}
+			catch (CannotParseArgException e)
+			{
+				//pass
+			}
+		}
+	}
+
+	@Test
+	public void testCannotDetermine()
+	{
+		for (List<String> inputs : CANNOT_DETERMINE_INPUTS)
+		{
+			try
+			{
+				parser.parse(inputs);
+				Assert.fail("should have thrown");
+			}
+			catch (CannotDetermineRolesException e)
+			{
+				// pass
+			}
+			catch (CannotParseArgException e)
+			{
+				Assert.fail(e.getMessage());
+			}
+		}
+	}
+}


### PR DESCRIPTION
I tried to make it so that all of my code affects the existing plugin code minimally. There are a lot of enums here (might seem like overkill for this particular PR), but I think most of them could be useful for the randomizer if you wanted to clean some of that up.

The parser's algorithm is a bit complex as it was originally made to parse inputs consisting of space-separated player names. With some small modifications it can be adjusted to allow for that, but even a good algorithm for this problem will produce ambiguous results for some inputs. The logic is unit tested at least, and (I hope) is documented decently.