### PR TITLE
Add new configuration option for keeping role preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## Changelog
+v2.0.2
+* Player 1 field is automatically filled in when clicked on (Must be logged in)
+* Reset button now disabled until first random is run
+* Clear button added clean the state completely
+* Fill unchecks itself if it detects other boxes have been unchecked (and vise versa)
+* UI pushes a GameMessage to the players chat if the config option is turned on in settings
+
+v2.0.1
+* Checkboxes instead of text input for player preferences
+
+v2.0.0
+* Added user interface to randomize roles instead of commandline
+* Now automatically removes previous roles that have been played already!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Role Randomizer
-_Based on the Bab discord bot_
-## Usage
+
+## v2.0.1 User interface
+---
+
+![user interface](https://media3.giphy.com/media/iYDzdsSe5FabJdyGbF/giphy.gif?cid=790b7611413273860b1de689549686a97bb87409a135bd60&rid=giphy.gif&ct=g)
+
+## v1.0.0 Commandline Usage
 
 ``::r <name> <prefs>(a/2/c/h/d/fill)``
 
@@ -23,30 +28,5 @@ _Based on the Bab discord bot_
 ``::prevr and ::rr``
 
 ![new commands](https://media2.giphy.com/media/VldmR7ubX8hrmBH0RW/giphy.gif)
-
-v2.0.1 User interface
----
-
-![user interface](https://media3.giphy.com/media/iYDzdsSe5FabJdyGbF/giphy.gif?cid=790b7611413273860b1de689549686a97bb87409a135bd60&rid=giphy.gif&ct=g)
-
-## TODO:
-- Not having to specify 'fill' should give the prefs of fill for the player
-- Leech mode (or for that fact, any "mode")
-
----
-## Changelog
-v2.0.2
-* Player 1 field is automatically filled in when clicked on (Must be logged in)
-* Reset button now disabled until first random is run
-* Clear button added clean the state completely
-* Fill unchecks itself if it detects other boxes have been unchecked (and vise versa)
-* UI pushes a GameMessage to the players chat if the config option is turned on in settings
-
-v2.0.1
-* Checkboxes instead of text input for player preferences
-
-v2.0.0
-* Added user interface to randomize roles instead of commandline
-* Now automatically removes previous roles that have been played already!
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Role Randomizer
 
-## v2.0.1 User interface
----
-
+## User interface
 ![user interface](https://media3.giphy.com/media/iYDzdsSe5FabJdyGbF/giphy.gif?cid=790b7611413273860b1de689549686a97bb87409a135bd60&rid=giphy.gif&ct=g)
 
-## v1.0.0 Commandline Usage
+## Commandline Usage
 
 ``::r <name> <prefs>(a/2/c/h/d/fill)``
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.rolerandomizer'
-version = '2.0.2'
+version = '2.0.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.15'
+def runeLiteVersion = '1.8.20'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/rolerandomizer/RoleRandomizerConfig.java
+++ b/src/main/java/com/rolerandomizer/RoleRandomizerConfig.java
@@ -40,4 +40,14 @@ public interface RoleRandomizerConfig extends Config
     {
         return false;
     }
+    
+    @ConfigItem(
+            keyName = "keepPreviousPreferences",
+            name = "Keep role preferences ticked",
+            description = "Keep role preferences ticked after the randomize button has been pressed"
+    }
+    default boolean keepPreferences()
+    {
+        return false;
+    }
 }

--- a/src/main/java/com/rolerandomizer/ui/RoleRandomizerPanel.java
+++ b/src/main/java/com/rolerandomizer/ui/RoleRandomizerPanel.java
@@ -399,11 +399,8 @@ public class RoleRandomizerPanel extends JPanel implements ActionListener {
                                     );
                                 }
                             }
-                            for (Map.Entry<Integer, String> entry: rr.usernames.entrySet()) {
-                                if (Objects.equals(entry.getValue(), roles[index])) {
-                                    rr.popPreference(entry.getKey(), index);
-                                    uncheckPreference(roles[index], index);
-                                }
+                            if (!config.keepPreferences()) {
+                                removeRolePreferences(roles, index);     
                             }
                             break;
                         case 1:
@@ -415,12 +412,7 @@ public class RoleRandomizerPanel extends JPanel implements ActionListener {
                                     );
                                 }
                             }
-                            for (Map.Entry<Integer, String> entry: rr.usernames.entrySet()) {
-                                if (Objects.equals(entry.getValue(), roles[index])) {
-                                    rr.popPreference(entry.getKey(), index);
-                                    uncheckPreference(roles[index], index);
-                                }
-                            }
+                            removeRolePreferences(roles, index);
                             break;
                         case 2:
                             panel.resultPanel.roleRandomizerResultField.append(" Healer\t" + roles[index] + "\n");
@@ -432,11 +424,8 @@ public class RoleRandomizerPanel extends JPanel implements ActionListener {
                                     );
                                 }
                             }
-                            for (Map.Entry<Integer, String> entry: rr.usernames.entrySet()) {
-                                if (Objects.equals(entry.getValue(), roles[index])) {
-                                    rr.popPreference(entry.getKey(), index);
-                                    uncheckPreference(roles[index], index);
-                                }
+                            if (!config.keepPreferences()) {
+                                removeRolePreferences(roles, index);     
                             }
                             break;
                         case 3:
@@ -449,11 +438,8 @@ public class RoleRandomizerPanel extends JPanel implements ActionListener {
                                     );
                                 }
                             }
-                            for (Map.Entry<Integer, String> entry: rr.usernames.entrySet()) {
-                                if (Objects.equals(entry.getValue(), roles[index])) {
-                                    rr.popPreference(entry.getKey(), index);
-                                    uncheckPreference(roles[index], index);
-                                }
+                            if (!config.keepPreferences()) {
+                                removeRolePreferences(roles, index);     
                             }
                             break;
                         case 4:
@@ -466,11 +452,8 @@ public class RoleRandomizerPanel extends JPanel implements ActionListener {
                                     );
                                 }
                             }
-                            for (Map.Entry<Integer, String> entry: rr.usernames.entrySet()) {
-                                if (Objects.equals(entry.getValue(), roles[index])) {
-                                    rr.popPreference(entry.getKey(), index);
-                                    uncheckPreference(roles[index], index);
-                                }
+                            if (!config.keepPreferences()) {
+                                removeRolePreferences(roles, index);     
                             }
                             break;
                     }
@@ -489,6 +472,15 @@ public class RoleRandomizerPanel extends JPanel implements ActionListener {
 
         } catch (Exception ex) {
             panel.resultPanel.roleRandomizerResultField.setText(" All roles exhausted or no prefs set");
+        }
+    }
+    
+    private void removeRolePreferences(String[] roles, int index) {
+        for (Map.Entry<Integer, String> entry: rr.usernames.entrySet()) {
+            if (Objects.equals(entry.getValue(), roles[index])) {
+                rr.popPreference(entry.getKey(), index);
+                uncheckPreference(roles[index], index);
+            }
         }
     }
 

--- a/src/main/java/com/rolerandomizer/ui/RoleRandomizerPanel.java
+++ b/src/main/java/com/rolerandomizer/ui/RoleRandomizerPanel.java
@@ -412,7 +412,9 @@ public class RoleRandomizerPanel extends JPanel implements ActionListener {
                                     );
                                 }
                             }
-                            removeRolePreferences(roles, index);
+                            if (!config.keepPreferences()) {
+                                removeRolePreferences(roles, index);     
+                            }
                             break;
                         case 2:
                             panel.resultPanel.roleRandomizerResultField.append(" Healer\t" + roles[index] + "\n");


### PR DESCRIPTION
Currently the way the UI randomizer works is it removes the roles after the 'randomize' button has been pressed.

This change will allow preferences to be saved, probably for longer runs. However this also means some players will get the same role multiple times in a row, maybe there should be some other logic for it?